### PR TITLE
fix baseURL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://elizen.me/"
 languageCode = "zh-CN"
 title = "Elizen"
 theme = "ivy"


### PR DESCRIPTION
你好，我用 RSS 订阅你的博客。当我今天准备阅读你的文章时，链接错误跳转。

这样添加 `baseURL` 就可以了
