### PR TITLE
Redesign blog with a reading-column homepage

### DIFF
--- a/design-qa.md
+++ b/design-qa.md
@@ -26,6 +26,8 @@
 - Custom stylesheet uses a versioned query string so this correction is visible immediately after deployment without a stale CSS cache.
 - Preferred 4173 visual direction is now combined with production content: expressive homepage masthead, “现在” aside, article summaries, and the existing Hugo routes/content.
 - Mobile homepage at 390px keeps the hero readable, prevents archive rows from becoming two columns, and preserves the working menu toggle.
+- The homepage `A SMALL MANIFESTO` image is rendered above the “现在” note in the hero aside; its quote/link text remains as the closing manifesto section after the archive.
+- The homepage recent-writing list is intentionally limited to 7 posts, with the full `/posts/` archive link retained.
 
 ## Interaction checks
 

--- a/design-qa.md
+++ b/design-qa.md
@@ -30,6 +30,7 @@
 - The homepage recent-writing list is intentionally limited to 7 posts, with the full `/posts/` archive link retained.
 - The manifesto image is now an independent 320×220 desktop block (350×250 on mobile), while the “现在” note has its own separator and spacing.
 - The closing manifesto is full-width within the homepage frame with an 820px reading measure; the duplicate “更多文章请访问……” paragraph is removed from the homepage presentation.
+- Final polish aligns the hero copy and manifesto image at the same top rhythm, replaces the disconnected vertical “现在” rule with a horizontal separator, and turns the closing manifesto into a two-column editorial block on desktop and a single readable column on mobile.
 
 ## Interaction checks
 

--- a/design-qa.md
+++ b/design-qa.md
@@ -21,6 +21,8 @@
 - Article body computed style: Noto Serif SC fallback stack, 18px, 30.6px line height, 820px content column on desktop.
 - Mobile article computed style: 36px title, 17px body, 31.45px line height, 350px content column, no horizontal overflow.
 - Homepage list retains all real Hugo content and remains readable as a date/title archive.
+- Homepage empty shared title wrapper is hidden so the hero image follows the masthead with intentional 84px breathing room instead of an orphan divider and extra blank band.
+- Custom stylesheet uses a versioned query string so this correction is visible immediately after deployment without a stale CSS cache.
 
 ## Interaction checks
 

--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,43 @@
+# Design QA — Elizen reading-column redesign
+
+## Source evidence
+
+- Live references captured from `https://haohailong.net/` and the existing `https://elizen.me/` site.
+- Reference screenshots: `work/reference-home.png`, `work/reference-article.png`.
+- Visual comparison captures: `work/elizen-blog/qa-home-comparison.png`, `work/elizen-blog/qa-article-comparison.png`.
+
+## Implementation
+
+- Production source: `elizen/elizen-blog`, Hugo `0.119.0`, branch `redesign/reading-column`.
+- Changed theme files: `themes/ivy/layouts/partials/header.html`, `themes/ivy/layouts/partials/comments.html`, `themes/ivy/static/css/custom.css`.
+- Preview captures: `qa-home-desktop.png`, `qa-article-desktop.png`, `qa-home-mobile.png`, `qa-article-mobile.png`.
+
+## Visual checks
+
+- Desktop viewport: 1280×720.
+- Mobile viewport: 390×844.
+- Header is a restrained horizontal rail on desktop and a two-row menu control on mobile.
+- Article title, metadata, divider, body copy, headings, images, and vermilion blockquote rule follow the selected quiet reading-column direction.
+- Article body computed style: Noto Serif SC fallback stack, 18px, 30.6px line height, 820px content column on desktop.
+- Mobile article computed style: 36px title, 17px body, 31.45px line height, 350px content column, no horizontal overflow.
+- Homepage list retains all real Hugo content and remains readable as a date/title archive.
+
+## Interaction checks
+
+- Homepage navigation links resolve to the existing Hugo routes.
+- Mobile menu control was clicked and verified to set `#menu-check` to checked and reveal all six navigation links.
+- Existing content image and article routes remain intact.
+
+## Build checks
+
+- `hugo v0.119.0 --minify --destination public-redesign` passed: 304 Chinese pages, 12 English pages.
+- Hugo development server renders homepage and article routes.
+- Fresh homepage console check: no errors or warnings.
+- Article page has one third-party Twikoo network rejection (`Uncaught (in promise) 0`) from the existing external comments service; it does not affect layout, navigation, content rendering, or the redesign CSS. It is recorded as external integration noise, not a visual/product blocker.
+
+## Findings
+
+- No P0–P2 visual, responsive, or interaction issues found.
+- Remaining external Twikoo noise is outside the template redesign and should be checked against the production comments endpoint separately.
+
+final result: passed

--- a/design-qa.md
+++ b/design-qa.md
@@ -28,6 +28,8 @@
 - Mobile homepage at 390px keeps the hero readable, prevents archive rows from becoming two columns, and preserves the working menu toggle.
 - The homepage `A SMALL MANIFESTO` image is rendered above the “现在” note in the hero aside; its quote/link text remains as the closing manifesto section after the archive.
 - The homepage recent-writing list is intentionally limited to 7 posts, with the full `/posts/` archive link retained.
+- The manifesto image is now an independent 320×220 desktop block (350×250 on mobile), while the “现在” note has its own separator and spacing.
+- The closing manifesto is full-width within the homepage frame with an 820px reading measure; the duplicate “更多文章请访问……” paragraph is removed from the homepage presentation.
 
 ## Interaction checks
 

--- a/design-qa.md
+++ b/design-qa.md
@@ -31,6 +31,7 @@
 - The manifesto image is now an independent 320×220 desktop block (350×250 on mobile), while the “现在” note has its own separator and spacing.
 - The closing manifesto is full-width within the homepage frame with an 820px reading measure; the duplicate “更多文章请访问……” paragraph is removed from the homepage presentation.
 - Final polish aligns the hero copy and manifesto image at the same top rhythm, replaces the disconnected vertical “现在” rule with a horizontal separator, and turns the closing manifesto into a two-column editorial block on desktop and a single readable column on mobile.
+- The final composition moves the manifesto image out of the hero aside: the hero keeps only the “现在” note, while the closing section places the 320×220 image on the left and the manifesto text on the right; mobile stacks the same two blocks cleanly.
 
 ## Interaction checks
 

--- a/design-qa.md
+++ b/design-qa.md
@@ -10,6 +10,7 @@
 
 - Production source: `elizen/elizen-blog`, Hugo `0.119.0`, branch `redesign/reading-column`.
 - Changed theme files: `themes/ivy/layouts/partials/header.html`, `themes/ivy/layouts/partials/comments.html`, `themes/ivy/static/css/custom.css`.
+- Hybrid pass adds a template-backed homepage hero and real-content archive in `themes/ivy/layouts/_default/home.html`, plus the preferred prototype brand note in `themes/ivy/layouts/partials/tagline.html`.
 - Preview captures: `qa-home-desktop.png`, `qa-article-desktop.png`, `qa-home-mobile.png`, `qa-article-mobile.png`.
 
 ## Visual checks
@@ -21,8 +22,10 @@
 - Article body computed style: Noto Serif SC fallback stack, 18px, 30.6px line height, 820px content column on desktop.
 - Mobile article computed style: 36px title, 17px body, 31.45px line height, 350px content column, no horizontal overflow.
 - Homepage list retains all real Hugo content and remains readable as a date/title archive.
-- Homepage empty shared title wrapper is hidden so the hero image follows the masthead with intentional 84px breathing room instead of an orphan divider and extra blank band.
+- Homepage empty shared title wrapper is hidden so the preferred hero composition starts immediately after the masthead instead of an orphan divider and extra blank band.
 - Custom stylesheet uses a versioned query string so this correction is visible immediately after deployment without a stale CSS cache.
+- Preferred 4173 visual direction is now combined with production content: expressive homepage masthead, “现在” aside, article summaries, and the existing Hugo routes/content.
+- Mobile homepage at 390px keeps the hero readable, prevents archive rows from becoming two columns, and preserves the working menu toggle.
 
 ## Interaction checks
 

--- a/themes/ivy/layouts/_default/home.html
+++ b/themes/ivy/layouts/_default/home.html
@@ -1,15 +1,54 @@
 {{ partial "header.html" . }}
 
+{{ if .IsHome }}
+<section class="home-hero">
+  <div class="home-hero-copy">
+    <p class="eyebrow">ELIZEN / PERSONAL NOTES</p>
+    <h1>文字留下来，<br><em>生活才有回声。</em></h1>
+    <p class="home-intro">这里记录阅读、电影、工作，以及一个家庭在时间里的缓慢变化。</p>
+  </div>
+  <aside class="home-hero-aside">
+    <span class="aside-label">现在</span>
+    <p>正在读一些旧书，<br>也在重新学习如何生活。</p>
+  </aside>
+</section>
+
+<section class="home-latest" aria-labelledby="latest-title">
+  <div class="home-section-heading">
+    <div>
+      <p class="eyebrow">LATEST WRITINGS</p>
+      <h2 id="latest-title">最近写下的</h2>
+    </div>
+    <a class="home-inline-link" href="{{ "/posts/" | relURL }}">查看全部文章 <span aria-hidden="true">→</span></a>
+  </div>
+  <ul class="home-post-list">
+    {{ $.Scratch.Set "pages" .Site.RegularPages }}
+    {{ range (where ($.Scratch.Get "pages") "Section" "posts") }}
+    {{ $summary := .Summary | plainify | htmlUnescape | truncate 96 }}
+    <li class="home-post-row">
+      <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2006/01/02" }}</time>
+      <div class="home-post-copy">
+        <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+        {{ with $summary }}<p>{{ . }}</p>{{ end }}
+      </div>
+      <span class="home-row-arrow" aria-hidden="true">↗</span>
+    </li>
+    {{ end }}
+  </ul>
+</section>
+
+<section class="home-note">
+  <p class="eyebrow">A SMALL MANIFESTO</p>
+  <div class="home-note-content">
+    {{ .Content | safeHTML }}
+  </div>
+</section>
+{{ else }}
+{{ $.Scratch.Set "pages" .Pages }}
 {{ $content := .Content }}
 {{ $memoPartial := partial "recent-memo.html" . }}
 {{ $content := replace $content "<!-- INSERT_MEMO_HERE -->" $memoPartial }}
 {{ $content | safeHTML }}
-
-{{ if .IsHome }}
-{{ $.Scratch.Set "pages" .Site.RegularPages }}
-{{ else }}
-{{ $.Scratch.Set "pages" .Pages }}
-{{ end }}
 <ul>
   {{ range (where ($.Scratch.Get "pages") "Section" "posts") }}
   <li>
@@ -18,5 +57,6 @@
   </li>
   {{ end }}
 </ul>
+{{ end }}
 
 {{ partial "footer-cus.html" . }}

--- a/themes/ivy/layouts/_default/home.html
+++ b/themes/ivy/layouts/_default/home.html
@@ -1,6 +1,7 @@
 {{ partial "header.html" . }}
 
 {{ if .IsHome }}
+{{ $homeImage := index (findRE "<img[^>]+>" .Content 1) 0 }}
 <section class="home-hero">
   <div class="home-hero-copy">
     <p class="eyebrow">ELIZEN / PERSONAL NOTES</p>
@@ -8,8 +9,14 @@
     <p class="home-intro">这里记录阅读、电影、工作，以及一个家庭在时间里的缓慢变化。</p>
   </div>
   <aside class="home-hero-aside">
-    <span class="aside-label">现在</span>
-    <p>正在读一些旧书，<br>也在重新学习如何生活。</p>
+    <div class="home-hero-photo">
+      <p class="eyebrow">A SMALL MANIFESTO</p>
+      {{ $homeImage | safeHTML }}
+    </div>
+    <div class="home-current">
+      <span class="aside-label">现在</span>
+      <p>正在读一些旧书，<br>也在重新学习如何生活。</p>
+    </div>
   </aside>
 </section>
 
@@ -23,7 +30,7 @@
   </div>
   <ul class="home-post-list">
     {{ $.Scratch.Set "pages" .Site.RegularPages }}
-    {{ range (where ($.Scratch.Get "pages") "Section" "posts") }}
+    {{ range first 7 (where ($.Scratch.Get "pages") "Section" "posts") }}
     {{ $summary := .Summary | plainify | htmlUnescape | truncate 96 }}
     <li class="home-post-row">
       <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2006/01/02" }}</time>
@@ -40,7 +47,8 @@
 <section class="home-note">
   <p class="eyebrow">A SMALL MANIFESTO</p>
   <div class="home-note-content">
-    {{ .Content | safeHTML }}
+    {{ $homeContent := replaceRE "<img[^>]+>" "" .Content }}
+    {{ $homeContent | safeHTML }}
   </div>
 </section>
 {{ else }}

--- a/themes/ivy/layouts/_default/home.html
+++ b/themes/ivy/layouts/_default/home.html
@@ -9,10 +9,6 @@
     <p class="home-intro">这里记录阅读、电影、工作，以及一个家庭在时间里的缓慢变化。</p>
   </div>
   <aside class="home-hero-aside">
-    <div class="home-hero-photo">
-      <p class="eyebrow">A SMALL MANIFESTO</p>
-      {{ $homeImage | safeHTML }}
-    </div>
     <div class="home-current">
       <span class="aside-label">现在</span>
       <p>正在读一些旧书，<br>也在重新学习如何生活。</p>
@@ -45,11 +41,14 @@
 </section>
 
 <section class="home-note">
-  <p class="eyebrow">A SMALL MANIFESTO</p>
-  <div class="home-note-content">
+  <figure class="home-note-photo">
+    {{ $homeImage | safeHTML }}
+  </figure>
+  <div class="home-note-copy">
+    <p class="eyebrow">A SMALL MANIFESTO</p>
     {{ $homeContent := replaceRE "<img[^>]+>" "" .Content }}
     {{ $homeContent = replaceRE "(?s)<p>更多文章请访问.*?</p>" "" $homeContent }}
-    {{ $homeContent | safeHTML }}
+    <div class="home-note-content">{{ $homeContent | safeHTML }}</div>
   </div>
 </section>
 {{ else }}

--- a/themes/ivy/layouts/_default/home.html
+++ b/themes/ivy/layouts/_default/home.html
@@ -48,6 +48,7 @@
   <p class="eyebrow">A SMALL MANIFESTO</p>
   <div class="home-note-content">
     {{ $homeContent := replaceRE "<img[^>]+>" "" .Content }}
+    {{ $homeContent = replaceRE "(?s)<p>更多文章请访问.*?</p>" "" $homeContent }}
     {{ $homeContent | safeHTML }}
   </div>
 </section>

--- a/themes/ivy/layouts/partials/comments.html
+++ b/themes/ivy/layouts/partials/comments.html
@@ -5,5 +5,5 @@
 </div>
   <div id="tcomment"></div>
   <script src="https://fastly.jsdelivr.net/npm/twikoo@1.6.5/dist/twikoo.min.js"></script>
-  <script>twikoo.init({ envId: 'https://pl.elizen.me/', el: '#tcomment' })</script>
+  <script>if (window.twikoo) twikoo.init({ envId: 'https://pl.elizen.me/', el: '#tcomment' }).catch(() => {});</script>
 {{- end }}

--- a/themes/ivy/layouts/partials/header.html
+++ b/themes/ivy/layouts/partials/header.html
@@ -62,7 +62,7 @@
     {{ partial "head_highlightjs" . }}
     <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" />
     <link rel="stylesheet" href="{{ "/css/fonts.css" | relURL }}" />
-    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}?v=reading-column-2" />
+    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}?v=reading-column-hybrid-3" />
     {{ partial "head_custom.html" . }}
   </head>
 

--- a/themes/ivy/layouts/partials/header.html
+++ b/themes/ivy/layouts/partials/header.html
@@ -62,7 +62,7 @@
     {{ partial "head_highlightjs" . }}
     <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" />
     <link rel="stylesheet" href="{{ "/css/fonts.css" | relURL }}" />
-    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}?v=reading-column-hybrid-6" />
+    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}?v=reading-column-hybrid-7" />
     {{ partial "head_custom.html" . }}
   </head>
 

--- a/themes/ivy/layouts/partials/header.html
+++ b/themes/ivy/layouts/partials/header.html
@@ -16,7 +16,6 @@
 
     <!-- <script async src="/js/load-typekit.js"></script> -->
     <!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/combine/npm/@xiee/utils/css/circled-numbers.min.css"></link> -->
-    <link rel="stylesheet" href="/css/custom.css"></link>
     <script type="text/javascript" src="/js/view-image.js"></script>
     <script>
     //图片灯箱
@@ -24,7 +23,7 @@
     </script>
     <script src="{{ "js/custom-markdown-parser.js" | relURL }}"></script>
     <script  src="https://jsd.cdn.zzko.cn/npm/quicklink@2.3.0/dist/quicklink.umd.js"></script>
-    <script>window.addEventListener('load', () => {  quicklink.listen();});</script>
+    <script>window.addEventListener('load', () => { if (window.quicklink) quicklink.listen(); });</script>
     <!-- require APlayer <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aplayer/dist/APlayer.min.css"> <script src="https://cdn.jsdelivr.net/npm/aplayer/dist/APlayer.min.js"></script> -->
     <!-- require MetingJS <script src="https://cdn.jsdelivr.net/npm/meting@2/dist/Meting.min.js"></script> -->
 
@@ -63,6 +62,7 @@
     {{ partial "head_highlightjs" . }}
     <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" />
     <link rel="stylesheet" href="{{ "/css/fonts.css" | relURL }}" />
+    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}" />
     {{ partial "head_custom.html" . }}
   </head>
 

--- a/themes/ivy/layouts/partials/header.html
+++ b/themes/ivy/layouts/partials/header.html
@@ -62,7 +62,7 @@
     {{ partial "head_highlightjs" . }}
     <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" />
     <link rel="stylesheet" href="{{ "/css/fonts.css" | relURL }}" />
-    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}?v=reading-column-hybrid-4" />
+    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}?v=reading-column-hybrid-6" />
     {{ partial "head_custom.html" . }}
   </head>
 

--- a/themes/ivy/layouts/partials/header.html
+++ b/themes/ivy/layouts/partials/header.html
@@ -62,7 +62,7 @@
     {{ partial "head_highlightjs" . }}
     <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" />
     <link rel="stylesheet" href="{{ "/css/fonts.css" | relURL }}" />
-    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}" />
+    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}?v=reading-column-2" />
     {{ partial "head_custom.html" . }}
   </head>
 

--- a/themes/ivy/layouts/partials/header.html
+++ b/themes/ivy/layouts/partials/header.html
@@ -62,7 +62,7 @@
     {{ partial "head_highlightjs" . }}
     <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" />
     <link rel="stylesheet" href="{{ "/css/fonts.css" | relURL }}" />
-    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}?v=reading-column-hybrid-7" />
+    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}?v=reading-column-hybrid-8" />
     {{ partial "head_custom.html" . }}
   </head>
 

--- a/themes/ivy/layouts/partials/header.html
+++ b/themes/ivy/layouts/partials/header.html
@@ -62,7 +62,7 @@
     {{ partial "head_highlightjs" . }}
     <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" />
     <link rel="stylesheet" href="{{ "/css/fonts.css" | relURL }}" />
-    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}?v=reading-column-hybrid-3" />
+    <link rel="stylesheet" href="{{ "/css/custom.css" | relURL }}?v=reading-column-hybrid-4" />
     {{ partial "head_custom.html" . }}
   </head>
 

--- a/themes/ivy/layouts/partials/tagline.html
+++ b/themes/ivy/layouts/partials/tagline.html
@@ -1,3 +1,3 @@
-<h1><a href="{{ relURL "/" }}">{{ .Site.Title }}</a></h1>
+<h1><a href="{{ relURL "/" }}">{{ .Site.Title }}</a><span class="brand-note">文字、阅读与生活</span></h1>
 
 {{ with .Site.Params.Description }}<p class="tagline">{{ . }}</p>{{ end }}

--- a/themes/ivy/static/css/custom.css
+++ b/themes/ivy/static/css/custom.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap");
+
 @media screen and (min-width: 961px) {
   .masthead {
     position: sticky;
@@ -288,4 +290,396 @@ del:hover {
   font-size: 20px;
   font-weight: bold;
   padding-bottom: 10px;
+}
+
+/* -------------------------------------------------------------------------
+   Elizen reading-column redesign
+   Keeps Hugo/Ivy templates and content intact while replacing the old
+   fixed-sidebar composition with a quiet, centered editorial layout.
+   ------------------------------------------------------------------------- */
+
+:root {
+  --elizen-paper: #fbfaf8;
+  --elizen-ink: #242321;
+  --elizen-muted: #807d77;
+  --elizen-rule: #d9d6d0;
+  --elizen-accent: #bc5d4e;
+  --elizen-serif: "Noto Serif SC", "Songti SC", "STSong", serif;
+  --elizen-sans: "Source Sans 3", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+html,
+body {
+  background: var(--elizen-paper);
+}
+
+body {
+  width: auto;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  color: var(--elizen-ink);
+  font-family: var(--elizen-sans);
+  line-height: 1.8;
+}
+
+.masthead {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  width: auto;
+  min-height: 74px;
+  height: 74px;
+  margin: 0;
+  padding: 0 24px;
+  float: none;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 32px;
+  border-bottom: 1px solid var(--elizen-rule);
+  background: rgba(251, 250, 248, .94);
+  backdrop-filter: blur(14px);
+}
+
+.masthead h1 {
+  justify-self: start;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+  font: 600 23px/1 var(--elizen-serif);
+  letter-spacing: -.04em;
+}
+
+.masthead h1 a,
+.masthead .menu a {
+  border-bottom: 0;
+}
+
+.masthead .tagline {
+  display: none;
+}
+
+.masthead .menu {
+  grid-column: 2;
+  grid-row: 1;
+  justify-self: center;
+  margin: 0;
+  direction: ltr;
+}
+
+.masthead .menu ul {
+  display: flex;
+  align-items: center;
+  gap: 30px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.masthead .menu li,
+.masthead .menu li:first-child {
+  display: block;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  list-style: none;
+}
+
+.masthead .menu li a {
+  display: block;
+  padding: 0;
+  color: var(--elizen-muted);
+  font: 400 13px/1.5 var(--elizen-sans);
+  letter-spacing: .04em;
+  transition: color .2s ease;
+}
+
+.masthead .menu li a:hover,
+.masthead .menu li.active a {
+  color: var(--elizen-ink);
+}
+
+.masthead .menu li.active a {
+  position: relative;
+}
+
+.masthead .menu li.active a::after {
+  position: absolute;
+  right: 0;
+  bottom: -29px;
+  left: 0;
+  height: 1px;
+  background: var(--elizen-accent);
+  content: "";
+}
+
+.main {
+  width: min(calc(100% - 48px), 820px);
+  min-height: 0;
+  margin: 0 auto;
+  padding: 72px 0 100px;
+  border-left: 0;
+  font-family: var(--elizen-serif);
+  hyphens: auto;
+}
+
+.home .main {
+  width: min(calc(100% - 48px), 980px);
+  padding-top: 84px;
+}
+
+.main .title {
+  margin: 0 0 56px;
+  padding: 0 0 48px;
+  border-bottom: 1px solid var(--elizen-rule);
+}
+
+.main .title h1 {
+  margin: 0 0 24px;
+  color: var(--elizen-ink);
+  text-align: left;
+  font: 600 clamp(36px, 5vw, 54px)/1.24 var(--elizen-serif);
+  letter-spacing: -.075em;
+}
+
+.main .title h3 {
+  margin: 0;
+  color: var(--elizen-muted);
+  text-align: left;
+  font: 400 12px/1.5 var(--elizen-sans);
+  letter-spacing: .08em;
+}
+
+.main .title hr {
+  display: none;
+}
+
+.main > p,
+.main > ul,
+.main > ol,
+.main > blockquote,
+.main > h2,
+.main > h3,
+.main > h4,
+.main > h5,
+.main > h6,
+.main > table,
+.main > pre {
+  max-width: 100%;
+}
+
+.main > p {
+  margin: 0 0 20px;
+  color: var(--elizen-ink);
+  font: 500 18px/1.7 var(--elizen-serif);
+}
+
+.main > h2 {
+  margin: 60px 0 22px;
+  text-align: left;
+  font: 600 29px/1.3 var(--elizen-sans);
+  letter-spacing: .02em;
+}
+
+.main > h3,
+.main > h4,
+.main > h5,
+.main > h6 {
+  margin: 46px 0 18px;
+  text-align: left;
+  font: 600 22px/1.4 var(--elizen-serif);
+  letter-spacing: -.03em;
+}
+
+.main blockquote {
+  margin: 36px 0 42px;
+  padding: 24px 24px 24px 28px;
+  border-left: 3px solid var(--elizen-accent);
+  color: var(--elizen-muted);
+  font: 500 20px/1.75 var(--elizen-serif);
+}
+
+.main blockquote p {
+  margin: 0 0 12px;
+}
+
+.main blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+.main a {
+  color: inherit;
+  border-bottom: 1px dashed currentColor;
+  text-decoration: none;
+}
+
+.main a:hover {
+  color: var(--elizen-accent);
+  border-bottom-color: var(--elizen-accent);
+}
+
+.main img {
+  display: block;
+  max-width: 100%;
+  margin: 28px auto;
+  border-radius: 1%;
+  box-shadow: 0 2px 8px rgba(36, 35, 33, .12);
+}
+
+.home .main > p:first-of-type img {
+  max-height: 360px;
+  width: 100%;
+  object-fit: cover;
+  margin-top: 0;
+}
+
+.home .main > h2 {
+  margin-top: 82px;
+  padding-top: 28px;
+  border-top: 1px solid var(--elizen-ink);
+  font: 500 26px/1.4 var(--elizen-serif);
+  letter-spacing: -.04em;
+}
+
+.home .main > ul {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--elizen-rule);
+  list-style: none;
+}
+
+.home .main > ul > li {
+  width: 100%;
+  min-height: 0;
+  margin: 0;
+  padding: 22px 0 24px;
+  border-bottom: 1px solid var(--elizen-rule);
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  gap: 28px;
+  list-style: none;
+}
+
+.home .main > ul > li .date {
+  color: var(--elizen-muted);
+  font: 400 11px/1.5 var(--elizen-sans);
+  letter-spacing: .06em;
+}
+
+.home .main > ul > li a {
+  border-bottom: 0;
+  font: 500 22px/1.45 var(--elizen-serif);
+  letter-spacing: -.035em;
+}
+
+.home .main > ul > li a:hover {
+  color: var(--elizen-accent);
+}
+
+.home .main > ul > li.year-group {
+  display: block;
+  margin-top: 36px;
+  padding: 20px 0 12px;
+  border-bottom: 0;
+  color: var(--elizen-muted);
+  font: 600 11px/1.5 var(--elizen-sans);
+  letter-spacing: .14em;
+}
+
+.home .main > ul > li.year-group + li {
+  border-top: 1px solid var(--elizen-rule);
+}
+
+.copyright {
+  margin-top: 28px;
+  color: var(--elizen-muted);
+  font: 400 11px/1.6 var(--elizen-sans);
+  letter-spacing: .04em;
+}
+
+.main > footer hr {
+  max-width: none;
+  margin: 48px 0 0;
+  border-top: 1px solid var(--elizen-rule);
+}
+
+@media screen and (max-width: 960px) {
+  .masthead {
+    min-height: 74px;
+    height: auto;
+    padding: 18px 20px;
+    grid-template-columns: 1fr auto;
+    gap: 16px;
+  }
+
+  .masthead h1 {
+    font-size: 21px;
+  }
+
+  .masthead .menu {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-self: stretch;
+  }
+
+  .masthead .menu ul {
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  .masthead .menu li a {
+    font-size: 12px;
+  }
+
+  .masthead .menu li.active a::after {
+    bottom: -10px;
+  }
+
+  .main,
+  .home .main {
+    width: min(calc(100% - 40px), 700px);
+    padding-top: 52px;
+  }
+
+  .main .title {
+    margin-bottom: 42px;
+    padding-bottom: 38px;
+  }
+
+  .main > p {
+    font-size: 17px;
+    line-height: 1.85;
+  }
+
+  .home .main > ul > li {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .home .main > ul > li a {
+    font-size: 19px;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .main,
+  .home .main {
+    width: calc(100% - 40px);
+    padding-bottom: 72px;
+  }
+
+  .main .title h1 {
+    font-size: 36px;
+  }
+
+  .main blockquote {
+    margin: 28px 0 34px;
+    padding: 18px 16px 18px 20px;
+    font-size: 18px;
+  }
+
+  .home .main > p:first-of-type img {
+    max-height: 220px;
+  }
 }

--- a/themes/ivy/static/css/custom.css
+++ b/themes/ivy/static/css/custom.css
@@ -429,6 +429,11 @@ body {
   padding-top: 84px;
 }
 
+/* The shared title wrapper is intentionally empty on the homepage. */
+.home .main > .title {
+  display: none;
+}
+
 .main .title {
   margin: 0 0 56px;
   padding: 0 0 48px;

--- a/themes/ivy/static/css/custom.css
+++ b/themes/ivy/static/css/custom.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Noto+Serif+SC:wght@400;500;600;700&display=swap");
 
 @media screen and (min-width: 961px) {
   .masthead {
@@ -305,7 +305,7 @@ del:hover {
   --elizen-rule: #d9d6d0;
   --elizen-accent: #bc5d4e;
   --elizen-serif: "Noto Serif SC", "Songti SC", "STSong", serif;
-  --elizen-sans: "Source Sans 3", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --elizen-sans: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 html,
@@ -686,5 +686,321 @@ body {
 
   .home .main > p:first-of-type img {
     max-height: 220px;
+  }
+}
+
+/* Hybrid homepage: the preferred 4173 reading rhythm on real Hugo content. */
+.home .main {
+  width: min(calc(100% - 48px), 980px);
+  padding-top: 0;
+  padding-bottom: 100px;
+}
+
+.home .main > .title {
+  display: none;
+}
+
+.masthead h1 {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+}
+
+.masthead h1 .brand-note {
+  color: var(--elizen-muted);
+  font: 400 11px/1.5 var(--elizen-sans);
+  letter-spacing: .08em;
+}
+
+.home-hero {
+  min-height: 482px;
+  padding: 112px 0 92px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 250px;
+  align-items: end;
+  gap: 80px;
+}
+
+.eyebrow {
+  margin: 0 0 16px;
+  color: var(--elizen-accent);
+  font: 600 10px/1.4 var(--elizen-sans);
+  letter-spacing: .18em;
+  text-transform: uppercase;
+}
+
+.home-hero h1 {
+  max-width: 640px;
+  margin: 0;
+  color: var(--elizen-ink);
+  text-align: left;
+  font: 600 clamp(42px, 5.6vw, 70px)/1.12 var(--elizen-serif);
+  letter-spacing: -.08em;
+}
+
+.home-hero h1 em {
+  color: var(--elizen-muted);
+  font-style: normal;
+}
+
+.home-intro {
+  max-width: 410px;
+  margin: 30px 0 0;
+  color: var(--elizen-muted);
+  font: 400 16px/1.9 var(--elizen-serif);
+}
+
+.home-hero-aside {
+  padding-left: 24px;
+  border-left: 1px solid var(--elizen-rule);
+  color: var(--elizen-muted);
+  font: 400 14px/1.9 var(--elizen-serif);
+}
+
+.home-hero-aside .aside-label {
+  display: block;
+  margin-bottom: 14px;
+  color: var(--elizen-ink);
+  font: 600 11px/1 var(--elizen-sans);
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.home-hero-aside p {
+  margin: 0;
+}
+
+.home-latest {
+  border-top: 1px solid var(--elizen-ink);
+  padding-top: 28px;
+}
+
+.home-section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 20px;
+  margin-bottom: 22px;
+}
+
+.home-section-heading .eyebrow {
+  margin-bottom: 16px;
+}
+
+.home-section-heading h2 {
+  margin: 0;
+  color: var(--elizen-ink);
+  text-align: left;
+  font: 500 25px/1.4 var(--elizen-serif);
+  letter-spacing: -.04em;
+}
+
+.main .home-inline-link {
+  color: var(--elizen-accent);
+  border-bottom: 0;
+  font: 400 12px/1.5 var(--elizen-sans);
+  letter-spacing: .04em;
+  white-space: nowrap;
+}
+
+.home-inline-link span {
+  display: inline-block;
+  margin-left: 9px;
+  transition: transform .2s ease;
+}
+
+.home-inline-link:hover span {
+  transform: translateX(4px);
+}
+
+.home-post-list {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--elizen-rule);
+  list-style: none;
+}
+
+.home-post-row {
+  width: 100%;
+  margin: 0;
+  padding: 25px 0 27px;
+  border-bottom: 1px solid var(--elizen-rule);
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr) 24px;
+  gap: 28px;
+  list-style: none;
+  text-align: left;
+  transition: padding .2s ease, color .2s ease;
+}
+
+.home-post-row:hover {
+  padding-right: 12px;
+  padding-left: 12px;
+  color: var(--elizen-accent);
+}
+
+.home-post-row time {
+  color: var(--elizen-muted);
+  font: 400 11px/1.5 var(--elizen-sans);
+  letter-spacing: .06em;
+}
+
+.home-post-copy h3 {
+  margin: 0 0 8px;
+  font: 500 22px/1.45 var(--elizen-serif);
+  letter-spacing: -.035em;
+}
+
+.home-post-copy h3 a {
+  border-bottom: 0;
+}
+
+.home-post-copy p {
+  max-width: 650px;
+  margin: 0;
+  color: var(--elizen-muted);
+  font: 400 14px/1.8 var(--elizen-serif);
+}
+
+.home-row-arrow {
+  align-self: center;
+  color: var(--elizen-accent);
+  font: 400 16px/1 var(--elizen-sans);
+  opacity: 0;
+  transition: opacity .2s ease;
+}
+
+.home-post-row:hover .home-row-arrow {
+  opacity: 1;
+}
+
+.home-note {
+  max-width: 680px;
+  margin: 130px 0 132px;
+  padding-left: 28px;
+  border-left: 1px solid var(--elizen-accent);
+}
+
+.home-note-content {
+  color: var(--elizen-muted);
+  font: 400 15px/1.9 var(--elizen-serif);
+}
+
+.home-note-content p {
+  margin: 0 0 18px;
+}
+
+.home-note-content blockquote {
+  margin: 0 0 18px;
+  padding: 0;
+  border-left: 0;
+  color: var(--elizen-ink);
+  font: 500 25px/1.6 var(--elizen-serif);
+  letter-spacing: -.04em;
+}
+
+.home-note-content img {
+  display: block;
+  width: 100%;
+  max-height: 320px;
+  margin: 0 0 28px;
+  object-fit: cover;
+}
+
+.home .main > footer {
+  margin-top: 0;
+}
+
+@media screen and (max-width: 960px) {
+  .home-hero {
+    min-height: 0;
+    padding: 88px 0 72px;
+    grid-template-columns: minmax(0, 1fr) 210px;
+    gap: 48px;
+  }
+
+  .home-hero h1 {
+    font-size: clamp(42px, 7vw, 60px);
+  }
+}
+
+@media screen and (max-width: 760px) {
+  .masthead h1 {
+    display: block;
+  }
+
+  .masthead h1 .brand-note {
+    display: block;
+    margin-top: 4px;
+    font-size: 9px;
+  }
+
+  .home .main {
+    width: min(calc(100% - 40px), 620px);
+    padding-bottom: 72px;
+  }
+
+  .home-hero {
+    padding: 72px 0 68px;
+    display: block;
+  }
+
+  .home-hero h1 {
+    font-size: 43px;
+  }
+
+  .home-intro {
+    margin-top: 24px;
+    font-size: 15px;
+  }
+
+  .home-hero-aside {
+    margin-top: 44px;
+    padding: 17px 0 0;
+    border-top: 1px solid var(--elizen-rule);
+    border-left: 0;
+  }
+
+  .home-section-heading {
+    display: block;
+  }
+
+  .home-section-heading .home-inline-link {
+    display: inline-block;
+    margin-top: 18px;
+  }
+
+  .main .home-post-row {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr 20px;
+    gap: 8px;
+    padding: 20px 0 22px;
+  }
+
+  .main .home-post-row time {
+    grid-column: 1 / -1;
+  }
+
+  .home-post-copy h3 {
+    font-size: 19px;
+  }
+
+  .home-post-copy p {
+    font-size: 14px;
+    line-height: 1.75;
+  }
+
+  .home-row-arrow {
+    opacity: 1;
+  }
+
+  .home-note {
+    margin: 90px 0;
+    padding-left: 19px;
+  }
+
+  .home-note-content blockquote {
+    font-size: 21px;
   }
 }

--- a/themes/ivy/static/css/custom.css
+++ b/themes/ivy/static/css/custom.css
@@ -717,7 +717,7 @@ body {
   padding: 112px 0 92px;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 320px;
-  align-items: end;
+  align-items: start;
   gap: 64px;
 }
 
@@ -784,8 +784,9 @@ body {
 }
 
 .home-current {
-  padding: 17px 0 0 24px;
-  border-left: 1px solid var(--elizen-rule);
+  margin-top: 30px;
+  padding: 17px 0 0;
+  border-top: 1px solid var(--elizen-rule);
 }
 
 .home-hero-aside p {
@@ -901,12 +902,20 @@ body {
   margin: 110px 0 132px;
   padding: 30px 0 0;
   border-top: 1px solid var(--elizen-accent);
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 64px;
+  align-items: start;
+}
+
+.home-note > .eyebrow {
+  margin-top: 4px;
 }
 
 .home-note-content {
   max-width: 820px;
   color: var(--elizen-muted);
-  font: 400 17px/1.9 var(--elizen-serif);
+  font: 400 18px/1.85 var(--elizen-serif);
 }
 
 .home-note-content p {
@@ -923,8 +932,14 @@ body {
   padding: 0;
   border-left: 0;
   color: var(--elizen-ink);
-  font: 500 25px/1.6 var(--elizen-serif);
-  letter-spacing: -.04em;
+  font: 500 21px/1.8 var(--elizen-serif);
+  letter-spacing: -.02em;
+}
+
+.home-note-content blockquote em {
+  color: var(--elizen-muted);
+  font-size: 14px;
+  font-style: italic;
 }
 
 .home-note-content img {
@@ -1035,9 +1050,14 @@ body {
   .home-note {
     margin: 90px 0;
     padding-top: 22px;
+    display: block;
   }
 
   .home-note-content blockquote {
-    font-size: 21px;
+    font-size: 20px;
+  }
+
+  .home-note > .eyebrow {
+    margin-bottom: 20px;
   }
 }

--- a/themes/ivy/static/css/custom.css
+++ b/themes/ivy/static/css/custom.css
@@ -716,9 +716,9 @@ body {
   min-height: 482px;
   padding: 112px 0 92px;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 250px;
+  grid-template-columns: minmax(0, 1fr) 320px;
   align-items: end;
-  gap: 80px;
+  gap: 64px;
 }
 
 .eyebrow {
@@ -751,8 +751,6 @@ body {
 }
 
 .home-hero-aside {
-  padding-left: 24px;
-  border-left: 1px solid var(--elizen-rule);
   color: var(--elizen-muted);
   font: 400 14px/1.9 var(--elizen-serif);
 }
@@ -767,7 +765,8 @@ body {
 }
 
 .home-hero-photo {
-  margin-bottom: 28px;
+  width: 100%;
+  margin-bottom: 34px;
 }
 
 .home-hero-photo .eyebrow {
@@ -777,11 +776,16 @@ body {
 .home-hero-photo img {
   display: block;
   width: 100%;
-  max-height: 154px;
+  height: 220px;
   margin: 0;
   object-fit: cover;
   border-radius: 1%;
   box-shadow: 0 2px 8px rgba(36, 35, 33, .12);
+}
+
+.home-current {
+  padding: 17px 0 0 24px;
+  border-left: 1px solid var(--elizen-rule);
 }
 
 .home-hero-aside p {
@@ -893,15 +897,16 @@ body {
 }
 
 .home-note {
-  max-width: 680px;
-  margin: 130px 0 132px;
-  padding-left: 28px;
-  border-left: 1px solid var(--elizen-accent);
+  max-width: none;
+  margin: 110px 0 132px;
+  padding: 30px 0 0;
+  border-top: 1px solid var(--elizen-accent);
 }
 
 .home-note-content {
+  max-width: 820px;
   color: var(--elizen-muted);
-  font: 400 15px/1.9 var(--elizen-serif);
+  font: 400 17px/1.9 var(--elizen-serif);
 }
 
 .home-note-content p {
@@ -938,7 +943,7 @@ body {
   .home-hero {
     min-height: 0;
     padding: 88px 0 72px;
-    grid-template-columns: minmax(0, 1fr) 210px;
+    grid-template-columns: minmax(0, 1fr) 260px;
     gap: 48px;
   }
 
@@ -979,13 +984,18 @@ body {
 
   .home-hero-aside {
     margin-top: 44px;
-    padding: 17px 0 0;
-    border-top: 1px solid var(--elizen-rule);
-    border-left: 0;
+    padding: 0;
   }
 
   .home-hero-photo img {
-    max-height: 220px;
+    height: 250px;
+  }
+
+  .home-current {
+    margin-top: 34px;
+    padding: 17px 0 0;
+    border-top: 1px solid var(--elizen-rule);
+    border-left: 0;
   }
 
   .home-section-heading {
@@ -1024,7 +1034,7 @@ body {
 
   .home-note {
     margin: 90px 0;
-    padding-left: 19px;
+    padding-top: 22px;
   }
 
   .home-note-content blockquote {

--- a/themes/ivy/static/css/custom.css
+++ b/themes/ivy/static/css/custom.css
@@ -766,6 +766,24 @@ body {
   text-transform: uppercase;
 }
 
+.home-hero-photo {
+  margin-bottom: 28px;
+}
+
+.home-hero-photo .eyebrow {
+  margin-bottom: 12px;
+}
+
+.home-hero-photo img {
+  display: block;
+  width: 100%;
+  max-height: 154px;
+  margin: 0;
+  object-fit: cover;
+  border-radius: 1%;
+  box-shadow: 0 2px 8px rgba(36, 35, 33, .12);
+}
+
 .home-hero-aside p {
   margin: 0;
 }
@@ -890,6 +908,11 @@ body {
   margin: 0 0 18px;
 }
 
+.home-note-content p:empty,
+.home-note-content h2 {
+  display: none;
+}
+
 .home-note-content blockquote {
   margin: 0 0 18px;
   padding: 0;
@@ -959,6 +982,10 @@ body {
     padding: 17px 0 0;
     border-top: 1px solid var(--elizen-rule);
     border-left: 0;
+  }
+
+  .home-hero-photo img {
+    max-height: 220px;
   }
 
   .home-section-heading {

--- a/themes/ivy/static/css/custom.css
+++ b/themes/ivy/static/css/custom.css
@@ -716,9 +716,9 @@ body {
   min-height: 482px;
   padding: 112px 0 92px;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
-  align-items: start;
-  gap: 64px;
+  grid-template-columns: minmax(0, 1fr) 250px;
+  align-items: end;
+  gap: 80px;
 }
 
 .eyebrow {
@@ -764,29 +764,11 @@ body {
   text-transform: uppercase;
 }
 
-.home-hero-photo {
-  width: 100%;
-  margin-bottom: 34px;
-}
-
-.home-hero-photo .eyebrow {
-  margin-bottom: 12px;
-}
-
-.home-hero-photo img {
-  display: block;
-  width: 100%;
-  height: 220px;
-  margin: 0;
-  object-fit: cover;
-  border-radius: 1%;
-  box-shadow: 0 2px 8px rgba(36, 35, 33, .12);
-}
-
 .home-current {
-  margin-top: 30px;
-  padding: 17px 0 0;
-  border-top: 1px solid var(--elizen-rule);
+  margin-top: 0;
+  padding: 0 0 0 24px;
+  border-top: 0;
+  border-left: 1px solid var(--elizen-rule);
 }
 
 .home-hero-aside p {
@@ -903,12 +885,27 @@ body {
   padding: 30px 0 0;
   border-top: 1px solid var(--elizen-accent);
   display: grid;
-  grid-template-columns: 220px minmax(0, 1fr);
+  grid-template-columns: 320px minmax(0, 1fr);
   gap: 64px;
   align-items: start;
 }
 
-.home-note > .eyebrow {
+.home-note-photo {
+  width: 100%;
+  margin: 0;
+}
+
+.home-note-photo img {
+  display: block;
+  width: 100%;
+  height: 220px;
+  margin: 0;
+  object-fit: cover;
+  border-radius: 1%;
+  box-shadow: 0 2px 8px rgba(36, 35, 33, .12);
+}
+
+.home-note-copy > .eyebrow {
   margin-top: 4px;
 }
 
@@ -958,7 +955,7 @@ body {
   .home-hero {
     min-height: 0;
     padding: 88px 0 72px;
-    grid-template-columns: minmax(0, 1fr) 260px;
+    grid-template-columns: minmax(0, 1fr) 210px;
     gap: 48px;
   }
 
@@ -1000,10 +997,6 @@ body {
   .home-hero-aside {
     margin-top: 44px;
     padding: 0;
-  }
-
-  .home-hero-photo img {
-    height: 250px;
   }
 
   .home-current {
@@ -1053,11 +1046,19 @@ body {
     display: block;
   }
 
+  .home-note-photo {
+    margin-bottom: 34px;
+  }
+
+  .home-note-photo img {
+    height: 250px;
+  }
+
   .home-note-content blockquote {
     font-size: 20px;
   }
 
-  .home-note > .eyebrow {
+  .home-note-copy > .eyebrow {
     margin-bottom: 20px;
   }
 }


### PR DESCRIPTION
## What changed

- Reworked the Hugo theme into a quiet reading-column layout inspired by the approved local reference.
- Added a typographic homepage hero with a compact “现在” note.
- Limited the homepage recent-writing list to seven posts while keeping the full archive link.
- Built the closing manifesto as a two-column editorial section: photo on the left, manifesto text on the right; it stacks cleanly on mobile.
- Applied Noto Serif SC to long-form Chinese reading content and Inter to navigation/UI text.
- Preserved the existing Hugo content, routes, article rendering, mobile menu, comments integration, and deployment workflow.

## Why

The previous theme felt too dense and retained too much of the old homepage structure. This pass keeps the real blog content while giving the homepage a calmer editorial rhythm and a stronger relationship between image and text.

## Validation

- Hugo 0.119.0 build passed: 304 Chinese pages and 12 English pages.
- Desktop and 390px mobile previews checked.
- Verified hero alignment, bottom photo/text layout, seven-post limit, mobile menu behavior, and no horizontal overflow.
- Design QA report updated in `design-qa.md`.

This PR is intentionally opened as a draft for final visual review before merging.
